### PR TITLE
Fix fucking darkmode

### DIFF
--- a/fuckingstyle.scss
+++ b/fuckingstyle.scss
@@ -17,7 +17,7 @@ h3 {
 
 @media (prefers-color-scheme: dark) {
   body {
-    color: white;
+    color: #CCCCCC;
     background: black;
   }
 

--- a/fuckingstyle.scss
+++ b/fuckingstyle.scss
@@ -17,7 +17,7 @@ h3 {
 
 @media (prefers-color-scheme: dark) {
   body {
-    color: #CCCCCC;
+    color: #ccc;
     background: black;
   }
 

--- a/fuckingstyle.scss
+++ b/fuckingstyle.scss
@@ -18,7 +18,7 @@ h3 {
 @media (prefers-color-scheme: dark) {
   body {
     color: white;
-    background: #444;
+    background: black;
   }
 
   a:link {


### PR DESCRIPTION
Make darkmode background black so users don't die in low-contrast grey shittiness

Seriously, look at this abomination:

![image](https://user-images.githubusercontent.com/2499896/116329224-352bbf00-a80e-11eb-9f54-feb01e8f3c10.png)

I can barely read the text through that grey obnoxious swamp of a background.

Now look at this clean beautiful sexy perfection:

![image](https://user-images.githubusercontent.com/2499896/116329307-6b693e80-a80e-11eb-9c18-b9a2a17ed6df.png)

OLED users can thank me later.