### PR TITLE
make favicon valid html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{ site.description | default: site.github.project_tagline }}">
     <link rel="stylesheet" href="{{ '/fuckingstyle.css?v=' | append: site.github.build_revision | relative_url }}">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖕</text></svg>">
+    <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48dGV4dCB5PSIuOWVtIiBmb250LXNpemU9IjkwIj7wn5aVPC90ZXh0Pjwvc3ZnPgo=">
   </head>
   <body>
     {{ content }}


### PR DESCRIPTION
Fixes html validation error by base64 encoding the svg embedded emoji.

https://validator.w3.org/nu/?doc=https%3A%2F%2Fperfectmotherfuckingwebsite.com